### PR TITLE
remove few deprecated API use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 
 Requests 0.4.0
 HttpCommon 0.2.4

--- a/src/api/keys.jl
+++ b/src/api/keys.jl
@@ -135,7 +135,7 @@ Base.haskey(cli::Client, key::String) = exists(cli, key)
 
 Removes the `key` from the etcd cluster.
 """
-delete(cli::Client, key::String) = delete(cli, key, Dict())
+delete(cli::Client, key::String) = delete(cli, key, Dict{String,Any}())
 
 """
     deletedir(cli, key; recursive=false) -> Dict

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,22 +1,23 @@
+global const ETCD_VER = "v3.2.12"
 global const ETCD_DEPS_PATH = joinpath(dirname(dirname(@__FILE__)), "deps")
 global const ETCD_SRC_PATH = if is_apple()
-    joinpath(ETCD_DEPS_PATH, "etcd-v2.3.7-darwin-amd64.zip")
+    joinpath(ETCD_DEPS_PATH, "etcd-$(ETCD_VER)-darwin-amd64.zip")
 elseif is_linux()
-    joinpath(ETCD_DEPS_PATH, "etcd-v2.3.7-linux-amd64.tar.gz")
+    joinpath(ETCD_DEPS_PATH, "etcd-$(ETCD_VER)-linux-amd64.tar.gz")
 end
 
 global const ETCD_DEST_PATH = if is_apple()
-    joinpath(ETCD_DEPS_PATH, "etcd-v2.3.7-darwin-amd64")
+    joinpath(ETCD_DEPS_PATH, "etcd-$(ETCD_VER)-darwin-amd64")
 elseif is_linux()
-    joinpath(ETCD_DEPS_PATH, "etcd-v2.3.7-linux-amd64")
+    joinpath(ETCD_DEPS_PATH, "etcd-$(ETCD_VER)-linux-amd64")
 end
 
 global const ETCD_BIN = joinpath(ETCD_DEST_PATH, "etcd")
 
 global const ETCD_DOWNLOAD_URI = if is_apple()
-    "https://github.com/coreos/etcd/releases/download/v2.3.7/etcd-v2.3.7-darwin-amd64.zip"
+    "https://github.com/coreos/etcd/releases/download/$(ETCD_VER)/etcd-$(ETCD_VER)-darwin-amd64.zip"
 elseif is_linux()
-    "https://github.com/coreos/etcd/releases/download/v2.3.7/etcd-v2.3.7-linux-amd64.tar.gz"
+    "https://github.com/coreos/etcd/releases/download/$(ETCD_VER)/etcd-$(ETCD_VER)-linux-amd64.tar.gz"
 else
     ""
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ Downloads and installs a local etcd server (mostly for testing).
 function install(force=true)
     if !isempty(ETCD_DOWNLOAD_URI)
         if !ispath(ETCD_SRC_PATH)
-            info(get_logger(current_module()), "Downloading etcd...")
+            info(getlogger(current_module()), "Downloading etcd...")
             download(ETCD_DOWNLOAD_URI, ETCD_SRC_PATH)
         end
 
@@ -28,7 +28,7 @@ The `timeout` specifies a number of seconds to run the server for
 (using `timeout` or `gtimeout`).
 """
 function start(timeout=-1)
-    info(get_logger(current_module()), "Starting etcd server...")
+    info(getlogger(current_module()), "Starting etcd server...")
 
     if !ispath(ETCD_DEST_PATH)
         install()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ const version = "v2"
         @testset "machines" begin
             resp = machines(cli)
             @test isa(resp, AbstractArray)
-            @test length(resp) == 2
+            @test length(resp) >= 1
             @test contains(resp[1], host)
             @test contains(resp[1], "$port")
         end


### PR DESCRIPTION
- `get_logger` was deprecated after invenia/Memento.jl#51
- move to Julia v0.6
- fix retry condition function
- use a more recent version of etcd