### PR TITLE
fix recursive watch

### DIFF
--- a/src/api/watch.jl
+++ b/src/api/watch.jl
@@ -18,7 +18,7 @@ function watch(f::Function, cli::Client, key::String; wait_index::Int=-1, recurs
             opts["waitIndex"] = wait_index
         end
 
-        resp = get(cli, key, opts)
+        resp = get(cli, key, opts; recursive=recursive)
         f(resp)
     end
 
@@ -50,7 +50,7 @@ function watchloop(
                 opts["waitIndex"] = wait_index
             end
 
-            resp = get(cli, key, opts)
+            resp = get(cli, key, opts; recursive=recursive)
             f(resp)
 
             if p(resp)


### PR DESCRIPTION
Method `watch` uses `get` internally, and `get` sets/overwrites `opts` based on keyword parameters passed to it. It must therefore pass appropriate values for the keyword parameters to avoid `get` overwriting them with default values.

This was resulting in the `recursive` flag being set to `false` always.