### PR TITLE
avoid duplicates and missed updates in watchloop

### DIFF
--- a/src/api/watch.jl
+++ b/src/api/watch.jl
@@ -57,6 +57,13 @@ function watchloop(
                 break
             end
 
+            # reset wait_index to modified index of the response
+            # - to avoid duplicates when the etcd index is incremented by updates elsewhere (outside the watched path)
+            # - and missed updates when wait_index was not initially supplied (for ones that happen between calls to `get`)
+            if ("node" in keys(resp)) && ("modifiedIndex" in keys(resp["node"]))
+                wait_index = resp["node"]["modifiedIndex"]
+            end
+
             if wait_index > 0
                 wait_index += 1
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Memento
 const LOG_LEVEL = "info"      # could also be "debug", "notice", "warn", etc
 
 Memento.config(LOG_LEVEL; fmt="[{level}] {msg}")
-const logger = get_logger(current_module())
+const logger = getlogger(current_module())
 
 # const timeout = 600     # A longer timeout for travis testing
 const timeout = 60    # More reasonable local timeout
@@ -280,7 +280,7 @@ const version = "v2"
                         c = Channel{Dict}(32)
                         set_resp = set(cli, "/mykey", "val1"; ttl=2)
                         idx = set_resp["node"]["modifiedIndex"] + 1
-                        predicate(r) = r["node"]["modifiedIndex"] > 5
+                        predicate(r) = r["node"]["modifiedIndex"] > (idx + 5)
 
                         t = watchloop(cli, "/mykey", predicate; wait_index=idx, recursive=true) do resp
                             put!(c, resp)


### PR DESCRIPTION
When a `wait_index` is specified, `watchloop` was incrementing it by `1` in every loop.
This can result in it getting duplicates if the etcd index is advanced in the meantime by updates elsewhere.

Also, when `wait_index` is not specified, there is a likelyhood of missing out on updates that would have happened between calls to `get`.

This fixes both the above issues by resetting `wait_index` in each loop from the `modifiedIndex` of the response received in that loop.
Also few minor fixes in tests.