### PR TITLE
include cause in error when available

### DIFF
--- a/src/requests.jl
+++ b/src/requests.jl
@@ -28,7 +28,9 @@ response(err::EtcdError) = err.resp
 function Base.showerror(io::IO, err::EtcdError)
     err_code = err.resp["errorCode"]
     msg = get(err.resp, "message", "Unknown error")
-    print(io, "EtcdError: $msg ($err_code).")
+    cause = get(err.resp, "cause", "")
+    isempty(cause) || (cause = " - $cause")
+    print(io, "EtcdError: $(msg)$(cause) ($err_code).")
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,7 @@ const version = "v2"
             catch err
                 @test isa(Etcd.response(err), Dict)
                 show_out = sprint(showerror, err)
-                @test startswith(show_out, "EtcdError: Key already exists (105).")
+                @test startswith(show_out, "EtcdError: Key already exists - /mykey (105).")
             end
 
             sleep(2)


### PR DESCRIPTION
Etcd error messages also provide a cause field that contains the entity on which an operation gave error.

This change is to include that in the message of the exception as I have often found it useful to know what caused the error.